### PR TITLE
(SERVER-1387) Add "small" role, tomcat dependencies

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,1 +1,9 @@
+# A Puppetfile for a control repo that can be used for Puppet Server / PE perf testing
+
+# Modules required to get a tomcat server up and running
 mod 'puppetlabs/tomcat', '1.5.0'
+mod 'puppetlabs/stdlib', '4.12.0'
+mod 'nanliu/staging', '1.0.3'
+mod 'puppetlabs/concat', '2.1.0'
+mod 'puppetlabs/java', '1.6.0'
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ we have a fixed reference point for reliable, repeatable test outcomes.
 
 ## How to use this repo during development
 
+This workflow assumes that on your branch, you've created an environment-specific
+`manifests/site.pp` file, which contains a `node 'default'` block that brings in
+the role that you are interested in.  With this pattern, any node that is using
+the specified environment is going to get that role as its classification, but
+presumably the only nodes that will be using the environment are nodes where this
+behavior is desirable.  We may want to look into a more sophisticated way to handle
+classification in the future.
+
+Steps:
+
 * Create a local `r10k.yaml` config file that looks something like this:
 
 ```
@@ -40,8 +50,7 @@ we have a fixed reference point for reliable, repeatable test outcomes.
 ```
 
 * Install r10k as a gem
-* Run something like `r10k deploy environment 20160614_memtest -v debug -c /my/scratch/dir/perf-control-repo/r10k.yamlhome/cprice/work/puppet-server/scratch/perf-control-repo/r10k.yaml`.  (You can leave out the environment name if you want to deploy all environments.)
+* Run something like `r10k deploy environment 20160614_memtest -p -v debug -c /my/scratch/dir/perf-control-repo/r10k.yamlhome/cprice/work/puppet-server/scratch/perf-control-repo/r10k.yaml`.  (You can leave out the environment name if you want to deploy all environments.)
 * Spin up a vmpooler VM to use as a test agent; install puppet-agent, configure the `server` to point to your host, and then run `puppet agent -t --environment 20160614_memtest`
-* Edit the `manifests/site.pp` file for the appropriate environment on your puppetserver to map a role to your vmpooler node
-* Re-run the agent, lather, rinse, repeat
+* Lather, rinse, repeat
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ we have a fixed reference point for reliable, repeatable test outcomes.
 
 ## How to use this repo during development
 
-This workflow assumes that on your branch, you've created an environment-specific
+This workflow assumes that you will be running puppetserver from source on your
+local machine.  Further, it assumes that after cloning this control repo,
+on the branch you're working on, you've created an environment-specific
 `manifests/site.pp` file, which contains a `node 'default'` block that brings in
 the role that you are interested in.  With this pattern, any node that is using
 the specified environment is going to get that role as its classification, but
@@ -50,7 +52,8 @@ Steps:
 ```
 
 * Install r10k as a gem
-* Run something like `r10k deploy environment 20160614_memtest -p -v debug -c /my/scratch/dir/perf-control-repo/r10k.yamlhome/cprice/work/puppet-server/scratch/perf-control-repo/r10k.yaml`.  (You can leave out the environment name if you want to deploy all environments.)
+* Make any desired changes to your local copy of the control repo, commit them, and push them up to the hubz.
+* To deploy the r10k environment to your local Puppet Server, run something like `r10k deploy environment 20160614_memtest -p -v debug -c /my/scratch/dir/perf-control-repo/r10k.yamlhome/cprice/work/puppet-server/scratch/perf-control-repo/r10k.yaml`.  (You can leave out the environment name if you want to deploy all environments.)
 * Spin up a vmpooler VM to use as a test agent; install puppet-agent, configure the `server` to point to your host, and then run `puppet agent -t --environment 20160614_memtest`
 * Lather, rinse, repeat
 

--- a/environment.conf
+++ b/environment.conf
@@ -1,0 +1,1 @@
+modulepath = modules:site:$basemodulepath

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,0 +1,3 @@
+node 'default' {
+  include ::role::by_size::small
+}

--- a/site/profile/manifests/tomcat/basic.pp
+++ b/site/profile/manifests/tomcat/basic.pp
@@ -1,0 +1,9 @@
+class profile::tomcat::basic {
+  include ::java
+  ::tomcat::install { '/opt/tomcat':
+    source_url => 'http://www-us.apache.org/dist/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz',
+  }
+  ::tomcat::instance { 'default':
+    catalina_home => '/opt/tomcat',
+  }
+}

--- a/site/role/manifests/by_size/small.pp
+++ b/site/role/manifests/by_size/small.pp
@@ -1,0 +1,3 @@
+class role::by_size::small {
+  include ::profile::tomcat::basic
+}


### PR DESCRIPTION
This commit adds a role called "role::by_size::small", which
just installs a tomcat server (and dependencies).  Also updates
the control repo to include the necessary module dependencies
for the tomcat module.
