### PR TITLE
Use archive.apache.org for older version of tomcat

### DIFF
--- a/modules/stall_things/lib/puppet/functions/stall.rb
+++ b/modules/stall_things/lib/puppet/functions/stall.rb
@@ -1,0 +1,11 @@
+# Put this in a module at <MODULE>/lib/puppet/functions/stall.rb
+Puppet::Functions.create_function(:stall) do
+  dispatch :stall do
+    param 'Numeric', :seconds
+  end
+
+  def stall(n)
+    sleep n
+    "dummy return value"
+  end
+end

--- a/modules/stall_things/manifests/init.pp
+++ b/modules/stall_things/manifests/init.pp
@@ -1,0 +1,5 @@
+class stall_things {
+  file { '/tmp/foo' :
+    content => stall_things(20)
+  }
+}

--- a/site/profile/manifests/tomcat/basic.pp
+++ b/site/profile/manifests/tomcat/basic.pp
@@ -1,7 +1,7 @@
 class profile::tomcat::basic {
   include ::java
   ::tomcat::install { '/opt/tomcat':
-    source_url => 'http://www-us.apache.org/dist/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz',
+    source_url => 'http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.69/bin/apache-tomcat-7.0.69.tar.gz',
   }
   ::tomcat::instance { 'default':
     catalina_home => '/opt/tomcat',


### PR DESCRIPTION
The previously used source for tomcat stopped using as soon as a new version
was released. This commit updates the source to use archive.apache.org
instead.
