### PR TITLE
(maint) Remove rampup_profile_gitlab

### DIFF
--- a/site/role/manifests/by_size/large.pp
+++ b/site/role/manifests/by_size/large.pp
@@ -3,6 +3,6 @@ class role::by_size::large {
 
   include ::profile::apache::basic
   include ::profile::influxdb::basic
-  include rampup_profile_gitlab
+#  include rampup_profile_gitlab
   include ::profile::loop_through_file_resources
 }


### PR DESCRIPTION
Module was breaking with the latest version of gatling